### PR TITLE
fix(sec): upgrade activemq-client to 5.15.9

### DIFF
--- a/game-engine/pom.xml
+++ b/game-engine/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>org.apache.activemq</groupId>
 			<artifactId>activemq-client</artifactId>
-			<version>5.15.7</version>
+			<version>5.15.9</version>
 		</dependency>
 
 


### PR DESCRIPTION
Upgrade activemq-client from 5.15.7 to 5.15.9 for vulnerability fix:
- [CVE-2019-0222](https://www.oscs1024.com/hd/MPS-2019-3178)